### PR TITLE
enable use of redis as session store in oauth2-proxy

### DIFF
--- a/distribution/oidc-auth/base/oauth2-proxy.yaml
+++ b/distribution/oidc-auth/base/oauth2-proxy.yaml
@@ -65,6 +65,10 @@ spec:
       #   value: "true"
       - name: extraArgs.insecure-oidc-allow-unverified-email
         value: "true"
+      - name: extraArgs.session-store-type
+        value: "redis"
+      - name: extraArgs.redis-connection-url
+        value: <<__oidc.redis.connection_url__>>
     repoURL: https://oauth2-proxy.github.io/manifests
     targetRevision: 3.3.2
   destination:


### PR DESCRIPTION
Use of redis as a session store was missing from oauth2-proxy even though the redis server is defined in the .conf files. 