### PR TITLE
Aibeyond jupyterwebapp customization

### DIFF
--- a/distribution/kubeflow/notebooks/jupyter-web-app/deployment.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       - name: jupyter-web-app
         #image: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
         image: 562046374233.dkr.ecr.us-west-2.amazonaws.com/ai.beyond/babylon/kubeflow/jupyter-web-app
+        imagePullPolicy: Always
         ports:
         - containerPort: 5000
         volumeMounts:

--- a/distribution/kubeflow/notebooks/jupyter-web-app/deployment.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/deployment.yaml
@@ -11,7 +11,8 @@ spec:
     spec:
       containers:
       - name: jupyter-web-app
-        image: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+        #image: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+        image: 562046374233.dkr.ecr.us-west-2.amazonaws.com/ai.beyond/babylon/kubeflow/jupyter-web-app
         ports:
         - containerPort: 5000
         volumeMounts:

--- a/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
@@ -12,6 +12,11 @@ patchesStrategicMerge:
 - deployment.yaml
 
 images:
-- name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
-  newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+- name: 562046374233.dkr.ecr.us-west-2.amazonaws.com/ai.beyond/babylon/kubeflow/jupyter-web-app
+  newName: 562046374233.dkr.ecr.us-west-2.amazonaws.com/ai.beyond/babylon/kubeflow/jupyter-web-app
   newTag: v1.3.0
+
+#- name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+#  newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+#  newTag: v1.3.0
+

--- a/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
@@ -4,7 +4,8 @@ namespace: kubeflow
 
 resources:
 - notebook_template.yaml
-- github.com/kubeflow/kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=0e91a2b9cd0c3b6687692b1f1f09ac6070cc6c3e # tag=v1.3.0
+#- github.com/kubeflow/kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=0e91a2b9cd0c3b6687692b1f1f09ac6070cc6c3e # tag=v1.3.0
+- github.com/paloul/argoflow-kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=aibeyond-jupyterwebapp-customization
 
 patchesStrategicMerge:
 - spawner_ui_config.yaml

--- a/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/kustomization.yaml
@@ -4,8 +4,8 @@ namespace: kubeflow
 
 resources:
 - notebook_template.yaml
-#- github.com/kubeflow/kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=0e91a2b9cd0c3b6687692b1f1f09ac6070cc6c3e # tag=v1.3.0
-- github.com/paloul/argoflow-kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=aibeyond-jupyterwebapp-customization
+- github.com/kubeflow/kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=0e91a2b9cd0c3b6687692b1f1f09ac6070cc6c3e # tag=v1.3.0
+#- github.com/paloul/argoflow-kubeflow/components/crud-web-apps/jupyter/manifests/overlays/istio?ref=aibeyond-jupyterwebapp-customization
 
 patchesStrategicMerge:
 - spawner_ui_config.yaml

--- a/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
@@ -23,9 +23,11 @@ data:
               imagePullPolicy: Always
               volumeMounts: []
               env: 
-                - name: NAMESPACE
+                - name: NB_USER
                   value: {namespace}
-                - name: NOTEBOOK_NAME
+                - name: NB_UID
+                  value: "1001"
+                - name: NB_NAME
                   value: {name}
               resources:
                 requests:

--- a/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
@@ -26,7 +26,7 @@ data:
                 - name: NB_USER
                   value: {namespace}
                 - name: NB_UID
-                  value: 1001
+                  value: "1001"
                 - name: NB_NAME
                   value: {name}
               resources:

--- a/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
@@ -23,11 +23,9 @@ data:
               imagePullPolicy: Always
               volumeMounts: []
               env: 
-                - name: NB_USER
+                - name: NAMESPACE
                   value: {namespace}
-                - name: NB_UID
-                  value: "1001"
-                - name: NB_NAME
+                - name: NOTEBOOK_NAME
                   value: {name}
               resources:
                 requests:

--- a/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
@@ -23,12 +23,12 @@ data:
               imagePullPolicy: Always
               volumeMounts: []
               env: 
-                - name: NAMESPACE
+                - name: NB_USER
                   value: {namespace}
-                - name: NOTEBOOK_NAME
+                - name: NB_UID
+                  value: 1001
+                - name: NB_NAME
                   value: {name}
-                - name: OAUTH_CALLBACK_URL
-                  value: "https://<<__subdomain_dashboard__>>.<<__domain__>>/notebook/{namespace}/{name}/lab/oauth_callback"
               resources:
                 requests:
                   cpu: "0.1"

--- a/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/notebook_template.yaml
@@ -20,6 +20,7 @@ data:
           containers:
             - name: {name}
               image: ""
+              imagePullPolicy: Always
               volumeMounts: []
               env: 
                 - name: NAMESPACE

--- a/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
@@ -108,7 +108,7 @@ data:
             # {none}: default StorageClass
             # {empty}: empty string ""
             value: 'efs-sc'
-        readOnly: true
+        readOnly: false
       dataVolumes:
         # List of additional Data Volumes to be attached to the user's Notebook
         value: []

--- a/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
@@ -102,12 +102,12 @@ data:
           accessModes:
             # The Access Mode of the Workspace Volume
             # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
-            value: ReadWriteMany
+            value: ReadWriteOnce
           class:
             # The StrageClass the PVC will use if type is New. Special values are:
             # {none}: default StorageClass
             # {empty}: empty string ""
-            value: efs-sc
+            value: {none}
         readOnly: false
       dataVolumes:
         # List of additional Data Volumes to be attached to the user's Notebook

--- a/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
@@ -59,7 +59,7 @@ data:
       # If false, users can only select from the images in this config
       imagePullPolicy:
         # Supported values: Always, IfNotPresent, Never
-        value: IfNotPresent
+        value: Always
         readOnly: false
       cpu:
         # CPU for user's Notebook

--- a/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
@@ -107,7 +107,7 @@ data:
             # The StrageClass the PVC will use if type is New. Special values are:
             # {none}: default StorageClass
             # {empty}: empty string ""
-            value: 'efs-sc'
+            value: efs-sc
         readOnly: false
       dataVolumes:
         # List of additional Data Volumes to be attached to the user's Notebook

--- a/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
+++ b/distribution/kubeflow/notebooks/jupyter-web-app/spawner_ui_config.yaml
@@ -102,13 +102,13 @@ data:
           accessModes:
             # The Access Mode of the Workspace Volume
             # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
-            value: ReadWriteOnce
+            value: ReadWriteMany
           class:
             # The StrageClass the PVC will use if type is New. Special values are:
             # {none}: default StorageClass
             # {empty}: empty string ""
-            value: '{none}'
-        readOnly: false
+            value: 'efs-sc'
+        readOnly: true
       dataVolumes:
         # List of additional Data Volumes to be attached to the user's Notebook
         value: []


### PR DESCRIPTION
This pullrequest includes a customized jupyter notebook and a jupyter-web-app of kubeflow to meet BL's needs. These changes here remove the use of the hardcoded jovyan in the Jupyter notebook and dynamically utilize the user name of the person logged in by grabbing the namespace from kubernetes/kubeflow. The changes here also remove hardcoded volume mounts to /home/jovyan, making them dynamic and mounting volumes to /home/{namespace} 